### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Bill of Materials
 **Other hardware:**
 Some vendors are suggested. See Bill of materials ODS file for more information.
 * 40cm Silicone 12mm OD, 8mm ID
- * [8MM I.D X 12MM O.D NGP60 Clear Transulcent Silicone Hose Pipe Tubing](http://www.advancedfluidsolutions.co.uk/8mm-id-x-12mm-od-clear-transulcent-silicone-hose-pipe-tubing-2480-p.asp) (USD$6.95)
+ * [8MM I.D X 12MM O.D NGP60 Clear Translucent Silicone Hose Pipe Tubing](http://www.advancedfluidsolutions.co.uk/8mm-id-x-12mm-od-clear-transulcent-silicone-hose-pipe-tubing-2480-p.asp) (USD$6.95)
 
 * 20cm UPVC 6mm OD, 4mm ID
  * [Hi-Flex 4mm ID - 6mm OD Flexible PVC Tubing : Clear](http://www.amazon.co.uk/Hi-Flex-4mm-ID-Flexible-Tubing/dp/B004CLLJFS) (USD$11.48)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Some vendors are suggested. See Bill of materials ODS file for more information.
 * Diaphragm: Cut from a report cover with approx 0.35mm plastic sheet
  * [Staples 21639 report cover (UPC 718103160223)](http://www.staples.ca/en/Staples-Swing-Lock-Report-Cover-Clear-with-Black-Spine-5-Pack/product_780953_2-CA_1_20001) (USD$8.84)
  
-* Silicone / Rubber ring for diaphram mount
+* Silicone / Rubber ring for diaphragm mount
 
 
 


### PR DESCRIPTION
On line 20 I fixed: Transulcent -> Translucent and on line 31: diaphram -> diaphragm

Original site that has the actual text also has these words spelled incorrectly.