### PR TITLE
Update and expansion of Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bill of Materials
 **Printed parts:**
 * 1 stethoscope head (head.stl)
 * 1 stethoscope ring (ring.stl)
-* 1 Y-piece
+* 1 Y-piece (y-piece.stl)
 * 2 ear tubes (eartube.stl)
 * 1 spring (spring.stl)
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,32 @@ Bill of Materials
 
 **Printed parts:**
 * 1 stethoscope head (head.stl)
+* 1 stethoscope ring (ring.stl)
+* 1 Y-piece
 * 2 ear tubes (eartube.stl)
-* 1 earplug mold (earplug_mold.stl)
+* 1 spring (spring.stl)
+
 
 **Other hardware:**
 Some vendors are suggested. See Bill of materials ODS file for more information.
 * 40cm Silicone 12mm OD, 8mm ID
  * [8MM I.D X 12MM O.D NGP60 Clear Translucent Silicone Hose Pipe Tubing](http://www.advancedfluidsolutions.co.uk/8mm-id-x-12mm-od-clear-transulcent-silicone-hose-pipe-tubing-2480-p.asp) (USD$6.95)
 
-* 20cm Silicone 6mm OD, 4mm ID
+* 20cm Silicone 8mm OD, 6mm ID
 
-* Silicone for ear plugs
- * [Moldable Silicone Ear Plugs](http://www.earplugstore.com/moldable-silicone-ear-plugs.html) (USD$1.80)
 
 * Diaphragm: 40mm diameter cut from a report cover with approx 0.35mm plastic sheet
  * [Staples 21639 report cover (UPC 718103160223)](http://www.staples.ca/en/Staples-Swing-Lock-Report-Cover-Clear-with-Black-Spine-5-Pack/product_780953_2-CA_1_20001) (USD$8.84)
  * You can cut the diaphragm by hand or with a stamp like [this one](https://www.amazon.ca/Karujimu-ki-jumbo-craft-circle-CN45004/dp/B001CBY41W)
+	
+	* Replacement earbud tips from an audio/electronics store, or make molded silicone ear plugs
  
 **Optional hardware**:
 * Metal spring for holding ear tubes together
-
+* 1 earplug mold (earplug_mold.stl)
+* Silicone for ear plugs
+ * [Moldable Silicone Ear Plugs](http://www.earplugstore.com/custom-diy-ear-plugs.html) (≥USD$9.50/pair)
+	* [Sugru](https://sugru.com/) (~£4-8/pair)
 
 
 Print Instructions
@@ -52,12 +58,15 @@ Assembly Instructions
 =====================
 
 * Insert silicone into mold and allow to set as per manufacturer instructions.
-* Attach the diaphragm (40mm) to the stethoscope head.
-* Attach the stethoscope head to the silicone tube.
-* Attach the silicone tube to the T-Piece.
-* Attach spring to ear tubes.
-* Attach the T-piece to the ear tubes.
-* Attach the ear tubes to the molded earplugs.
+* Place the diaphragm (40mm) on the stethoscope head and fasten the printed ring over it.
+* Attach the stethoscope head to the 8mm ID silicone tube.
+* Attach the other end of the 8mm ID tube to the large end of the Y-piece.
+* Attach the earplugs onto the matching grooves on the eartubes.
+* Cut the 6mm ID silicone tubing in half.
+* Attach the two 6mm ID tubes to the eartubes.
+* Thread the two holes of the 3D printed spring through these tubes, and press them onto where the 6mm ID tube and the printed eartube meet.
+	* Optionally, test the width of the spring by placing the eartubes, now connected by the spring, into your ears. Remove the spring and use a heat gun to bend the spring as desired.
+* Attach the other ends of the two 6mm ID tubes to the smaller ends of the Y-Piece.
 * Test the stethoscope as per the validation instructions.
 
 


### PR DESCRIPTION
Bill of Materials: Printed parts
     - Added missing parts, update for OTC earbud tips

Bill of Materials: Others
     - Changed ID of smaller silicone tubes to fit onto eartubes; the printed eartubes have an ED of 6mm and it was very difficult to fit 4mm ID tubes onto these.
     - Silicone for ear plugs changed link as current does not actually set i.e. inappropriate

Assembly Instructions:
     - Added more detail and changed order